### PR TITLE
Added ability for columns to execute a method when a model has been s…

### DIFF
--- a/docs/columns.md
+++ b/docs/columns.md
@@ -148,6 +148,13 @@ getTranformFromRepository()
     internally stored in the model. Receives a single argument containing the repository value
     and should return the transformed value.
 
+getOnSavedCallback()
+:   If required this should return a call back function that executes after a model using the column has been
+    saved to the repository. This can be used to represent data stored outside the repository itself or for
+    manipulations of the value which can only occur once the model has a unique identifier. An example use case
+    would be for a column type that populates a many to many table from an array, e.g. a Tags column. The reverse
+    process can be accomplished using getTransformFromRepository(), no counterpart call back is needed.
+
 getStorageColumn()
 :   Some generic column types perform useful data transformations making our life as a developer a lot easier,
     for example the Json column. Ultimately the Json column stores it's data in a simple string column type.

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -91,7 +91,8 @@ abstract class Repository
             $this->columnTransforms[$column->columnName] =
                 [
                     $storageColumn->getTransformFromRepository(),
-                    $storageColumn->getTransformIntoRepository()
+                    $storageColumn->getTransformIntoRepository(),
+                    $storageColumn->getOnSavedCallback()
                 ];
         }
     }
@@ -429,6 +430,13 @@ abstract class Repository
         }
 
         $this->cacheObjectData($object);
+
+        foreach( $this->columnTransforms as $columnName => $transforms ){
+            if ( $transforms[2] !== null ){
+                $callback = $transforms[2];
+                $callback( $object );
+            }
+        }
     }
 
     public final function deleteObject(Model $object)

--- a/src/Schema/Columns/Column.php
+++ b/src/Schema/Columns/Column.php
@@ -114,6 +114,20 @@ class Column
         return false;
     }
 
+    /**
+     * Optionally returns a Closure that will execute after a model using the column has been saved to the repository.
+     *
+     * We use closures here for speed - we want to cache these methods into an array on the Repository so that
+     * we don't have to call these methods for every set and get on the model - only where the column has
+     * defined these values.
+     *
+     * @return null
+     */
+    public function getOnSavedCallback()
+    {
+        return null;
+    }
+
 
     /**
      * Optionally returns a Closure that can transform model data as it is set by the user of the model.

--- a/tests/Schema/Columns/EncryptedStringTest.php
+++ b/tests/Schema/Columns/EncryptedStringTest.php
@@ -4,7 +4,9 @@ namespace Rhubarb\Stem\Tests\Schema\Columns;
 
 use Rhubarb\Crown\Encryption\EncryptionProvider;
 use Rhubarb\Crown\Encryption\UnitTesting\UnitTestingAes256EncryptionProvider;
+use Rhubarb\Crown\Tests\Encryption\UnitTestingAes256EncryptionProvider;
 use Rhubarb\Stem\Models\Model;
+use Rhubarb\Stem\Schema\Columns\EncryptedString;
 use Rhubarb\Stem\Schema\ModelSchema;
 use Rhubarb\Crown\Tests\RhubarbTestCase;
 

--- a/tests/Schema/Columns/PostSaveColumn.php
+++ b/tests/Schema/Columns/PostSaveColumn.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rhubarb\Stem\Tests\Schema\Columns;
+
+use Rhubarb\Crown\Tests\RhubarbTestCase;
+use Rhubarb\Stem\Models\Model;
+use Rhubarb\Stem\Schema\Columns\Column;
+use Rhubarb\Stem\Schema\ModelSchema;
+
+class PostSaveColumn extends RhubarbTestCase
+{
+    public function testSaveMethodIsCalled()
+    {
+        $test = new TestModel();
+        $test->Test = "abc123";
+
+        $test->save();
+
+        $this->assertEquals( "abc123", TestColumn::$tested );
+    }
+}
+
+class TestModel extends Model
+{
+
+    /**
+     * Returns the schema for this data object.
+     *
+     * @return \Rhubarb\Stem\Schema\ModelSchema
+     */
+    protected function createSchema()
+    {
+        $schema = new ModelSchema( "test" );
+        $schema->addColumn( new TestColumn( "Test" ) );
+
+        return $schema;
+    }
+}
+
+class TestColumn extends Column
+{
+    public static $tested = false;
+
+    public function getOnSavedCallback()
+    {
+        return function( $model ){
+          self::$tested = $model[ $this->columnName ];
+        };
+    }
+}


### PR DESCRIPTION
…aved in order to round out it's functionality

Check the update to the docs, a use case is in representing a simple many-to-many relationship as an array in the model, without having to add an afterSave() override to the model itself (which splits the functionality into two places)