### PR TITLE
Ac/collection batch update

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -269,3 +269,6 @@ If any of the 3 rules above fail, calling batchUpdate will throw a `BatchUpdateN
 are unsure if your Collection meets the criteria AND still want to support falling back to the iterative
 approach (and you understand and accept the scalability issues that this might involve) you can pass true
 as the optional second argument to this function to do iteration as a fallback if Repository updating fails.
+
+As a general guide you should only call batchUpdate while passing true as a second parameter if you are
+100% confident you require it, and that the size of any iteration is going to be within safe limits.

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -392,7 +392,9 @@ class Collection implements \ArrayAccess, \Iterator, \Countable
      *
      * @param Array $propertyPairs An associative array of key value pairs to update
      * @param bool $fallBackToIteration If the repository can't perform the action directly, perform the update by
-     *                                  iterating over all the models in the collection.
+     *                                  iterating over all the models in the collection. You should only pass true
+     *                                  if you know that the collection doesn't meet the criteria for an optimised
+     *                                  update and the iteration of items won't cause problems
      * @return Collection The original collection returned for chaining
      * @throws BatchUpdateNotPossibleException Thrown if the repository for the collection can't perform the update,
      *                                         and $fallBackToIteration is false.

--- a/src/Exceptions/BatchUpdateNotPossibleException.php
+++ b/src/Exceptions/BatchUpdateNotPossibleException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rhubarb\Stem\Exceptions;
+
+use Rhubarb\Crown\Exceptions\RhubarbException;
+
+class BatchUpdateNotPossibleException extends RhubarbException
+{
+    public function __construct()
+    {
+        parent::__construct("Batch updating this collection is not possible");
+    }
+}

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -43,10 +43,6 @@ use Rhubarb\Stem\Schema\SolutionSchema;
  */
 abstract class Model extends ModelState
 {
-    use EventEmitter {
-        RaiseEvent as TraitRaiseEvent;
-    }
-
     private $eventsToRaiseAfterSave = [];
 
     public final function __construct($uniqueIdentifier = null)
@@ -115,7 +111,13 @@ abstract class Model extends ModelState
             }
 
             if ($column->defaultValue !== null) {
-                $this[$column->columnName] = $column->defaultValue;
+                $defaultValue = $column->defaultValue;
+
+                if ( is_object($defaultValue) ){
+                    $defaultValue = clone( $defaultValue );
+                }
+
+                $this[$column->columnName] = $defaultValue;
             }
         }
     }

--- a/src/Repositories/MySql/Schema/MySqlComparisonSchema.php
+++ b/src/Repositories/MySql/Schema/MySqlComparisonSchema.php
@@ -58,11 +58,13 @@ class MySqlComparisonSchema
         $columns = $schema->getColumns();
 
         foreach ($columns as $column) {
-            // The column might be using a more generic type for it's storage.
-            $storageColumn = $column->getStorageColumn();
-            // And if so that column will be a generic column type - we need to upgrade it.
-            $storageColumn = $storageColumn->getRepositorySpecificColumn("MySql");
-            $comparisonSchema->columns[$column->columnName] = $storageColumn->getDefinition();
+            // The column might be using more generic types for it's storage.
+            $storageColumns = $column->createStorageColumns();
+            foreach( $storageColumns as $storageColumn ) {
+                // And if so that column will be a generic column type - we need to upgrade it.
+                $storageColumns = $storageColumn->getRepositorySpecificColumn("MySql");
+                $comparisonSchema->columns[$column->columnName] = $storageColumn->getDefinition();
+            }
         }
 
         $indexes = $schema->indexes;

--- a/src/Repositories/MySql/Schema/MySqlComparisonSchema.php
+++ b/src/Repositories/MySql/Schema/MySqlComparisonSchema.php
@@ -62,8 +62,8 @@ class MySqlComparisonSchema
             $storageColumns = $column->createStorageColumns();
             foreach( $storageColumns as $storageColumn ) {
                 // And if so that column will be a generic column type - we need to upgrade it.
-                $storageColumns = $storageColumn->getRepositorySpecificColumn("MySql");
-                $comparisonSchema->columns[$column->columnName] = $storageColumn->getDefinition();
+                $storageColumn = $storageColumn->getRepositorySpecificColumn("MySql");
+                $comparisonSchema->columns[$storageColumn->columnName] = $storageColumn->getDefinition();
             }
         }
 

--- a/src/Repositories/MySql/Schema/MySqlModelSchema.php
+++ b/src/Repositories/MySql/Schema/MySqlModelSchema.php
@@ -122,10 +122,13 @@ class MySqlModelSchema extends ModelSchema
 
         foreach ($this->columns as $columnName => $column) {
             // The column might be using a more generic type for it's storage.
-            $storageColumn = $column->getStorageColumn();
-            // And if so that column will be a generic column type - we need to upgrade it.
-            $storageColumn = $storageColumn->getRepositorySpecificColumn("MySql");
-            $definitions[] = $storageColumn->getDefinition();
+            $storageColumns = $column->createStorageColumns();
+
+            foreach( $storageColumns as $storageColumn ) {
+                // And if so that column will be a generic column type - we need to upgrade it.
+                $storageColumn = $storageColumn->getRepositorySpecificColumn("MySql");
+                $definitions[] = $storageColumn->getDefinition();
+            }
         }
 
         foreach ($this->indexes as $indexName => $index) {

--- a/src/Repositories/PdoRepository.php
+++ b/src/Repositories/PdoRepository.php
@@ -193,25 +193,6 @@ abstract class PdoRepository extends Repository
     }
 
     /**
-     * Checks if raw repository data needs transformed before passing to the model.
-     *
-     * @param $modelData
-     * @return mixed
-     */
-    protected function transformDataFromRepository($modelData)
-    {
-        foreach ($this->columnTransforms as $columnName => $transforms) {
-            if ($transforms[0] !== null) {
-                $closure = $transforms[0];
-
-                $modelData[$columnName] = $closure($modelData[$columnName]);
-            }
-        }
-
-        return $modelData;
-    }
-
-    /**
      * Executes the statement and returns the first column of the first row.
      *
      * @param $statement

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -211,6 +211,22 @@ abstract class Repository
     }
 
     /**
+     * Commits changes to the repository in batch against a collection.
+     *
+     * @param Collection $collection
+     * @param $propertyPairs
+     */
+    public function batchCommitUpdatesFromCollection(
+        Collection $collection,
+        $propertyPairs )
+    {
+        foreach( $collection as $item ){
+            $item->mergeRawData( $propertyPairs );
+            $item->save();
+        }
+    }
+
+    /**
      * Computes the given aggregates and returns an array of answers
      *
      * An answer will be null if the repository is unable to answer it.

--- a/src/Schema/Columns/Column.php
+++ b/src/Schema/Columns/Column.php
@@ -58,7 +58,7 @@ class Column
     }
 
     /**
-     * Returns a column object capable of supplying the schema details for this column.
+     * Returns an array of column objects capable of supplying the schema details for this column.
      *
      * Normally a column can specify it's own schema, however sometimes a column extends another column type
      * simply to add some transforms, for example Json extends LongString and adds json encoding and decoding.
@@ -67,10 +67,31 @@ class Column
      *
      * By overriding this function you can delegate the storage of the raw data to another simpler column
      * type that has already had the repository specific instances created.
+     *
+     * @return Column[]
      */
-    public function getStorageColumn()
+    public function createStorageColumns()
     {
-        return $this;
+        return [ $this ];
+    }
+
+    /**
+     * Returns an array of named columns needed for storage.
+     *
+     * @see createStorageColumns()
+     * @return Column[]
+     */
+    public function getStorageColumns()
+    {
+        $columns = $this->createStorageColumns();
+
+        $namedColumns = [];
+
+        foreach( $columns as $column ){
+            $namedColumns[ $column->columnName ] = $column;
+        }
+
+        return $namedColumns;
     }
 
     /**

--- a/src/Schema/Columns/CommaSeparatedList.php
+++ b/src/Schema/Columns/CommaSeparatedList.php
@@ -31,23 +31,23 @@ class CommaSeparatedList extends String
     public function getTransformIntoRepository()
     {
         return function ($data) {
-            if (!is_array($data)) {
+            if (!is_array($data[$this->columnName])) {
                 return "";
             }
 
-            return implode(",", $data);
+            return implode(",", $data[$this->columnName]);
         };
     }
 
     public function getTransformFromRepository()
     {
         return function ($data) {
-            return explode(",", $data);
+            return explode(",", $data[$this->columnName]);
         };
     }
 
-    public function getStorageColumn()
+    public function createStorageColumns()
     {
-        return new String($this->columnName, $this->maximumLength, $this->defaultValue);
+        return [ new String($this->columnName, $this->maximumLength, $this->defaultValue) ];
     }
 }

--- a/src/Schema/Columns/CompositeColumn.php
+++ b/src/Schema/Columns/CompositeColumn.php
@@ -33,6 +33,8 @@ abstract class CompositeColumn extends Column
         parent::__construct($columnName, $this->getNewContainerObject() );
     }
 
+
+
     /**
      * Returns an array of strings; the names of the composite columns being used.
      *

--- a/src/Schema/Columns/CompositeColumn.php
+++ b/src/Schema/Columns/CompositeColumn.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Stem\Schema\Columns;
+
+use Rhubarb\Crown\Modelling\AllPublicModelState;
+
+/**
+ * A column type that can present a group of 'sub columns' in a single datastructure.
+ *
+ * Useful for doing things like Address structures without requiring the model designer to add
+ * all the backing columns and allow for an easier way to pass the Address structure around.
+ */
+abstract class CompositeColumn extends Column
+{
+    public function __construct($columnName)
+    {
+        parent::__construct($columnName, $this->getNewContainerObject() );
+    }
+
+    /**
+     * Returns an array of strings; the names of the composite columns being used.
+     *
+     * e.g. [ "Line1", "Line2", "City", "Country" ]
+     *
+     * @return array
+     */
+    protected abstract function getCompositeColumnsNames();
+
+    /**
+     * Returns the container object used to represent the collated data.
+     *
+     * Uses AllPublicModelState by default which is fine unless you need a more mature
+     * model object.
+     */
+    protected function getNewContainerObject()
+    {
+        return new AllPublicModelState();
+    }
+
+    public function getTransformFromRepository()
+    {
+        return function( $data ){
+            $address = $this->getNewContainerObject();
+
+            foreach( $this->getCompositeColumnsNames() as $column ){
+                if ( isset($data[$this->columnName.$column]) ) {
+                    $address[$column] = $data[$this->columnName.$column];
+                }
+            }
+
+            return $address;
+        };
+    }
+
+    public function getTransformIntoRepository()
+    {
+        return function( $data ){
+            $exportData = [];
+
+            foreach( $this->getCompositeColumnsNames() as $column ) {
+                $exportData[ $this->columnName.$column ] = isset( $data[ $column ] ) ? $data[ $column ] : "";
+            }
+
+            return $exportData;
+        };
+    }
+}

--- a/src/Schema/Columns/FilterSettings.php
+++ b/src/Schema/Columns/FilterSettings.php
@@ -32,15 +32,15 @@ class FilterSettings extends Json
 
     public function getTransformIntoRepository()
     {
-        return function ($value) {
-            return json_encode($value->getSettingsArray());
+        return function ($data) {
+            return json_encode($data[$this->columnName]->getSettingsArray());
         };
     }
 
     public function getTransformFromRepository()
     {
-        return function ($value) {
-            $value = json_decode($value, true);
+        return function ($data) {
+            $value = json_decode($data[$this->columnName], true);
 
             return Filter::speciateFromSettingsArray($value);
         };

--- a/src/Schema/Columns/Json.php
+++ b/src/Schema/Columns/Json.php
@@ -34,12 +34,12 @@ class Json extends LongString
 	{
 		return function( $data )
 		{
-			return json_encode( $data );
+			return json_encode( $data[ $this->columnName ] );
 		};
 	}
 
-	public function getStorageColumn()
+	public function createStorageColumns()
 	{
-		return new LongString($this->columnName);
+		return [ new LongString($this->columnName) ];
 	}
 }

--- a/src/Schema/Columns/WithEncryptedText.php
+++ b/src/Schema/Columns/WithEncryptedText.php
@@ -26,7 +26,7 @@ trait WithEncryptedText
     {
         return function ($data) {
             $encryption = EncryptionProvider::getEncryptionProvider();
-            return $encryption->encrypt($data, $this->columnName);
+            return $encryption->encrypt($data[$this->columnName], $this->columnName);
         };
     }
 
@@ -34,12 +34,12 @@ trait WithEncryptedText
     {
         return function ($data) {
             $encryption = EncryptionProvider::getEncryptionProvider();
-            return $encryption->decrypt($data, $this->columnName);
+            return $encryption->decrypt($data[$this->columnName], $this->columnName);
         };
     }
 
-    public function getStorageColumn()
+    public function createStorageColumns()
     {
-        return new String($this->columnName, $this->maximumLength, $this->defaultValue);
+        return [ new String($this->columnName, $this->maximumLength, $this->defaultValue) ];
     }
 }

--- a/tests/Collections/CollectionMySqlTest.php
+++ b/tests/Collections/CollectionMySqlTest.php
@@ -7,15 +7,62 @@ namespace Gcd\Tests;
  * @author acuthbert
  * @copyright GCD Technologies 2012
  */
+use Rhubarb\Stem\Exceptions\BatchUpdateNotPossibleException;
 use Rhubarb\Stem\Exceptions\SortNotValidException;
 use Rhubarb\Stem\Filters\Equals;
 use Rhubarb\Stem\Collections\Collection;
+use Rhubarb\Stem\Filters\GreaterThan;
 use Rhubarb\Stem\Repositories\MySql\MySql;
 use Rhubarb\Stem\Tests\Repositories\MySql\MySqlTestCase;
 use Rhubarb\Stem\Tests\Fixtures\Company;
 
 class CollectionMySqlTest extends MySqlTestCase
 {
+	public function testBatchUpdate()
+	{
+		MySql::executeStatement( "TRUNCATE TABLE tblCompany" );
+
+		$company = new Company();
+		$company->CompanyName = "GCD";
+		$company->Active = true;
+		$company->save();
+
+		$company = new Company();
+		$company->CompanyName = "Unit Design";
+		$company->Active = true;
+		$company->save();
+
+		$company = new Company();
+		$company->CompanyName = "Goats Boats";
+		$company->Active = true;
+		$company->save();
+
+		Company::find()->batchUpdate( [ "CompanyName" => "Test Company" ] );
+
+		$lastStatement = MySql::getPreviousStatement();
+
+		$this->assertStringStartsWith( "UPDATE `tblCompany` SET `CompanyName` = :UpdateCompanyName WHERE `tblCompany`.`Active` = ", $lastStatement );
+
+		$count = MySql::returnSingleValue( "SELECT COUNT(*) FROM tblCompany WHERE CompanyName = 'Test Company'" );
+
+		$this->assertEquals( 3, $count );
+
+		try {
+			Company::find(new GreaterThan("CompanyIDSquared", 0,
+				true))->batchUpdate(["CompanyName" => "Test Company 2"]);
+
+			$this->fail( "Batch update shouldn't have been allowed if not filtered by the repository." );
+		}
+		catch( BatchUpdateNotPossibleException $er ){}
+
+		Company::find(new GreaterThan("CompanyIDSquared", 0,
+			true))->batchUpdate(["CompanyName" => "Test Company 2"], true );
+
+		$count = MySql::returnSingleValue( "SELECT COUNT(*) FROM tblCompany WHERE CompanyName = 'Test Company 2'" );
+
+		$this->assertEquals( 3, $count );
+	}
+
 	public function testDataListFetchesObjects()
 	{
 		MySql::executeStatement( "TRUNCATE TABLE tblCompany" );

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rhubarb\Stem\Tests\Collections\CollectionTest;
+
+use Rhubarb\Crown\Tests\RhubarbTestCase;
+use Rhubarb\Stem\Tests\Fixtures\Company;
+
+class CollectionTest extends RhubarbTestCase
+{
+    public function testBatchUpdate()
+    {
+        $a = new Company();
+        $a->CompanyName = "a";
+        $a->Active = true;
+        $a->save();
+
+        $b = new Company();
+        $b->CompanyName = "b";
+        $b->Active = true;
+        $b->save();
+
+        $c = new Company();
+        $c->CompanyName = "c";
+        $c->Active = true;
+        $c->save();
+
+        $companies = Company::find()->batchUpdate(
+            [
+                "CompanyName" => "d"
+            ]
+        );
+
+        foreach( $companies as $company )
+        {
+            $this->assertEquals( "d", $company->CompanyName );
+        }
+    }
+}


### PR DESCRIPTION
Note: This was branched from #12 - merge it first to clean up the commits.

Added support for doing batch updates to all models in a collection. Repositories can optimise this to a single query under certain conditions. Documentation provided.