### PR TITLE
Columns define PHP datatype

### DIFF
--- a/src/Schema/Columns/Boolean.php
+++ b/src/Schema/Columns/Boolean.php
@@ -22,6 +22,11 @@ require_once __DIR__ . "/Column.php";
 
 class Boolean extends Column
 {
+    public function getPhpType()
+    {
+        return "bool";
+    }
+
     public function getTransformIntoModelData()
     {
         return function ($value) {

--- a/src/Schema/Columns/Column.php
+++ b/src/Schema/Columns/Column.php
@@ -45,6 +45,11 @@ class Column
         $this->defaultValue = $defaultValue;
     }
 
+    public function getPhpType()
+    {
+        return "string";
+    }
+
     /**
      * Return the definition string needed to update the back end storage schema to match.
      *

--- a/src/Schema/Columns/CommaSeparatedList.php
+++ b/src/Schema/Columns/CommaSeparatedList.php
@@ -28,6 +28,11 @@ class CommaSeparatedList extends String
         parent::__construct($columnName, $maximumLength, $defaultValue);
     }
 
+    public function getPhpType()
+    {
+        return "string[]";
+    }
+
     public function getTransformIntoRepository()
     {
         return function ($data) {

--- a/src/Schema/Columns/CompositeColumn.php
+++ b/src/Schema/Columns/CompositeColumn.php
@@ -33,6 +33,11 @@ abstract class CompositeColumn extends Column
         parent::__construct($columnName, $this->getNewContainerObject());
     }
 
+    public function getPhpType()
+    {
+        return "string[]";
+    }
+
     /**
      * Returns an array of strings; the names of the composite columns being used.
      *

--- a/src/Schema/Columns/Date.php
+++ b/src/Schema/Columns/Date.php
@@ -24,6 +24,11 @@ require_once __DIR__ . "/Column.php";
 
 class Date extends Column
 {
+    public function getPhpType()
+    {
+        return '\\' . RhubarbDate::class;
+    }
+
     public function getTransformIntoModelData()
     {
         return function ($data) {

--- a/src/Schema/Columns/DateTime.php
+++ b/src/Schema/Columns/DateTime.php
@@ -24,6 +24,11 @@ use Rhubarb\Crown\DateTime\RhubarbDateTime;
 
 class DateTime extends Date
 {
+    public function getPhpType()
+    {
+        return '\\' . RhubarbDateTime::class;
+    }
+
     public function getTransformIntoModelData()
     {
         return function ($data) {

--- a/src/Schema/Columns/Decimal.php
+++ b/src/Schema/Columns/Decimal.php
@@ -40,6 +40,11 @@ class Decimal extends Column
         $this->minValue = $this->maxValue * -1;
     }
 
+    public function getPhpType()
+    {
+        return "float";
+    }
+
     /**
      * @return int
      */

--- a/src/Schema/Columns/Float.php
+++ b/src/Schema/Columns/Float.php
@@ -22,5 +22,8 @@ require_once __DIR__ . "/Column.php";
 
 class Float extends Column
 {
-
+    public function getPhpType()
+    {
+        return "float";
+    }
 }

--- a/src/Schema/Columns/Integer.php
+++ b/src/Schema/Columns/Integer.php
@@ -22,4 +22,8 @@ require_once __DIR__ . "/Column.php";
 
 class Integer extends Column
 {
+    public function getPhpType()
+    {
+        return "int";
+    }
 }

--- a/src/Schema/Columns/Json.php
+++ b/src/Schema/Columns/Json.php
@@ -36,6 +36,11 @@ class Json extends LongString
         $this->decodeAsArrays = $decodeAsArrays;
     }
 
+    public function getPhpType()
+    {
+        return \stdClass::class;
+    }
+
     public function getTransformFromRepository()
     {
         return function ($data) {

--- a/src/Schema/Columns/Time.php
+++ b/src/Schema/Columns/Time.php
@@ -24,6 +24,11 @@ use Rhubarb\Crown\DateTime\RhubarbTime;
 
 class Time extends Column
 {
+    public function getPhpType()
+    {
+        return '\\' . RhubarbTime::class;
+    }
+
     public function getTransformIntoModelData()
     {
         return function ($data) {

--- a/src/Schema/SolutionSchema.php
+++ b/src/Schema/SolutionSchema.php
@@ -131,7 +131,17 @@ abstract class SolutionSchema
     }
 
     /**
-     * Get's an empty model of the appropriate type for a given model name.
+     * Gets an array of all named models and their class names
+     *
+     * @return Model[]
+     */
+    public function getAllModels()
+    {
+        return $this->models;
+    }
+
+    /**
+     * Gets an empty model of the appropriate type for a given model name.
      *
      * @param      $modelName
      * @param null $uniqueIdentifier Optionally a unique identifier to load.


### PR DESCRIPTION
This was mainly written for Custard's document-models command, as it allows it to ask the Columns in a Model what type they should have in the `@property [type] $Field` definition. You can try it out by putting some Custard on your project and running that command.