### PR TITLE
Improved Model::isNewRecord()

### DIFF
--- a/src/Repositories/MySql/MySql.php
+++ b/src/Repositories/MySql/MySql.php
@@ -40,18 +40,7 @@ class MySql extends PdoRepository
         if ($object->isNewRecord()) {
             $this->insertObject($object);
         } else {
-            $rowsUpdated = $this->updateObject($object);
-
-            if ( $rowsUpdated == 0 ){
-                $schema = $object->getSchema();
-                $columns = $schema->getColumns();
-
-                // String based unique identifiers won't appear to Stem as needing inserted.
-                // We will insert them if the update fails (i.e. updates no rows).
-                if ( !($columns[$schema->uniqueIdentifierColumnName] instanceof AutoIncrement ) ) {
-                    $this->insertObject($object);
-                }
-            }
+            $this->updateObject($object);
         }
     }
 

--- a/tests/Fixtures/Account.php
+++ b/tests/Fixtures/Account.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rhubarb\Stem\Tests\Fixtures;
+
+use Rhubarb\Stem\Models\Model;
+use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\ModelSchema;
+
+/**
+ * A class with a string ID
+ * @package Rhubarb\Stem\Tests\Fixtures
+ *
+ * @property string $AccountID
+ * @property string $AccountName
+ */
+class Account extends Model
+{
+
+    /**
+     * @return \Rhubarb\Stem\Schema\ModelSchema
+     */
+    protected function createSchema()
+    {
+        $schema = new ModelSchema('tblAccount');
+        $schema->addColumn(
+            new String('AccountID', 50),
+            new String('AccountName', 50)
+        );
+        $schema->uniqueIdentifierColumnName = 'AccountID';
+
+        return $schema;
+    }
+}

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -397,6 +397,8 @@ class ModelTest extends ModelUnitTestCase
         $example = new Example($example->UniqueIdentifier);
         $this->assertTrue($example->loaded);
 
+
+        // This is the old, bad pattern. Unless this can be justified - importing into a new record is NOT loading.
         $example = new Example();
         $example->importRawData(["a" => "b"]);
 
@@ -404,7 +406,7 @@ class ModelTest extends ModelUnitTestCase
 
         $example->importRawData([$example->UniqueIdentifierColumnName => 2]);
 
-        $this->assertTrue($example->loaded);
+        $this->assertFalse($example->loaded);
     }
 
     public function testModelGetsDefaultValues()

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -11,6 +11,7 @@ use Rhubarb\Stem\Repositories\MySql\Schema\Columns\MySqlDate;
 use Rhubarb\Stem\Schema\Columns\String;
 use Rhubarb\Stem\Schema\ModelSchema;
 use Rhubarb\Stem\Schema\SolutionSchema;
+use Rhubarb\Stem\Tests\Fixtures\Account;
 use Rhubarb\Stem\Tests\Fixtures\Company;
 use Rhubarb\Stem\Tests\Fixtures\Example;
 use Rhubarb\Stem\Tests\Fixtures\ModelUnitTestCase;
@@ -422,4 +423,32 @@ class ModelTest extends ModelUnitTestCase
 
         $this->assertTrue($newContact->isNewRecord());
     }
+
+    public function testIsNewRecordFlagWithNonAutoIncrementID()
+    {
+        $account = new Account();
+        $account->AccountID = 'test1';
+        $account->AccountName = 'test 1';
+
+        $this->assertTrue($account->isNewRecord());
+        $account->save();
+        $this->assertFalse($account->isNewRecord());
+
+        $accountReload = new Account('test1');
+        $this->assertFalse($accountReload->isNewRecord());
+        $accountReload->AccountName = 'test 1-1';
+        $accountReload->save();
+        $this->assertFalse($accountReload->isNewRecord());
+
+        $accountImport = new Account();
+        $this->assertTrue( $accountImport->isNewRecord() );
+        $accountImport->importRawData( [
+            'AccountName' => 'Account 2',
+            'AccountID' => 'Account2',
+        ] );
+        $this->assertTrue( $accountImport->isNewRecord() );
+        $accountImport->save();
+        $this->assertFalse( $accountImport->isNewRecord() );
+    }
+
 }


### PR DESCRIPTION
Now safe to use with models which don't have an auto increment id as their unique identifier.
This required a few tweaks to model behaviour (around `ImportRawData` and `onLoaded`).