### PR TITLE
PHP 7 Support

### DIFF
--- a/docs/columns.md
+++ b/docs/columns.md
@@ -41,10 +41,10 @@ understood.
 Column              | Description
 --------------------|------------
 Integer             |Stores whole numbers
-Float               |Stores floating point numbers
+FloatColumn               |Stores floating point numbers
 Decimal             |Stores decimal numbers with a fixed range of decimal places
 Money               |A Decimal column hard coded to 2 decimal places
-String              |Stores text data with a configurable maximum length
+StringColumn              |Stores text data with a configurable maximum length
 EncryptedString     |Stores encrypted text data
 LongString          |Stores text data with an unlimited length
 DateTime            |Stores date time data
@@ -176,10 +176,10 @@ getStorageColumns()
     {
         return
         [
-            new String("AddressLine1",50),
-            new String("City",50),
-            new String("Region",50),
-            new String("Country",50)
+            new StringColumn("AddressLine1",50),
+            new StringColumn("City",50),
+            new StringColumn("Region",50),
+            new StringColumn("Country",50)
         ];
     }
     ```
@@ -194,10 +194,10 @@ getStorageColumns()
     {
         return
         [
-            new String($this->columnName."Line1",50),
-            new String($this->columnName."City",50),
-            new String($this->columnName."Region",50),
-            new String($this->columnName."Country",50)
+            new StringColumn($this->columnName."Line1",50),
+            new StringColumn($this->columnName."City",50),
+            new StringColumn($this->columnName."Region",50),
+            new StringColumn($this->columnName."Country",50)
         ];
     }
     ```

--- a/docs/models-and-schemas.md
+++ b/docs/models-and-schemas.md
@@ -90,8 +90,8 @@ class Customer extends ModelObject
 		$schema->addColumn(
 			new AutoIncrement( "CustomerID" ),
 			new ForeignKey( "CustomerID" ),
-			new String( "Forename", 200 ),
-			new String( "Surname", 200 ),
+			new StringColumn( "Forename", 200 ),
+			new StringColumn( "Surname", 200 ),
 			new Integer( "LastOrderID" )
 		);
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -18,7 +18,7 @@ class CoalBucket extends ModelObject
 
 		$schema->AddColumns(
 			new AutoIncrement( "CoalBucketID" ),
-			new String( "BucketName", 200 ),
+			new StringColumn( "BucketName", 200 ),
 			new Integer( "Capacity" )
 		);
 
@@ -60,13 +60,13 @@ schema definition in the back end is up to date.
 These classes are extended by repository specific versions of columns and set out some basic
 behaviours for various data types.
 
-String
+StringColumn
 :   Text columns
 
 Integer
 :   Integer number columns
 
-Float
+FloatColumn
 :   Floating precision number columns
 
 Boolean

--- a/src/Repositories/MySql/Schema/Columns/MySqlMediumText.php
+++ b/src/Repositories/MySql/Schema/Columns/MySqlMediumText.php
@@ -18,12 +18,12 @@
 
 namespace Rhubarb\Stem\Repositories\MySql\Schema\Columns;
 
-require_once __DIR__ . "/../../../../Schema/Columns/String.php";
+require_once __DIR__ . "/../../../../Schema/Columns/StringColumn.php";
 require_once __DIR__ . "/MySqlColumn.php";
 
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 
-class MySqlMediumText extends String
+class MySqlMediumText extends StringColumn
 {
     use MySqlColumn;
 

--- a/src/Repositories/MySql/Schema/Columns/MySqlString.php
+++ b/src/Repositories/MySql/Schema/Columns/MySqlString.php
@@ -18,13 +18,13 @@
 
 namespace Rhubarb\Stem\Repositories\MySql\Schema\Columns;
 
-require_once __DIR__ . "/../../../../Schema/Columns/String.php";
+require_once __DIR__ . "/../../../../Schema/Columns/StringColumn.php";
 require_once __DIR__ . "/MySqlColumn.php";
 
 use Rhubarb\Stem\Schema\Columns\Column;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 
-class MySqlString extends String
+class MySqlString extends StringColumn
 {
     use MySqlColumn;
 

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -26,7 +26,7 @@ use Rhubarb\Stem\Exceptions\SortNotValidException;
 use Rhubarb\Stem\Models\Model;
 use Rhubarb\Stem\Repositories\Offline\Offline;
 use Rhubarb\Stem\Schema\Columns\Date;
-use Rhubarb\Stem\Schema\Columns\Float;
+use Rhubarb\Stem\Schema\Columns\FloatColumn;
 use Rhubarb\Stem\Schema\Columns\Integer;
 use Rhubarb\Stem\Schema\ModelSchema;
 
@@ -319,7 +319,7 @@ abstract class Repository
             if (isset($columns[$columnName])) {
                 $column = $columns[$columnName];
 
-                if ($column instanceof Integer || $column instanceof Float ) {
+                if ($column instanceof Integer || $column instanceof FloatColumn ) {
                     $type = SORT_NUMERIC;
                 } elseif ( $column instanceof Date ){
                     $type = SORT_REGULAR;

--- a/src/Schema/Columns/CommaSeparatedList.php
+++ b/src/Schema/Columns/CommaSeparatedList.php
@@ -21,7 +21,7 @@ namespace Rhubarb\Stem\Schema\Columns;
 /**
  * Provides functionality to encode an array of items (normally ids) as a comma separated list
  */
-class CommaSeparatedList extends String
+class CommaSeparatedList extends StringColumn
 {
     public function __construct($columnName, $maximumLength = 200, $defaultValue = [])
     {
@@ -56,6 +56,6 @@ class CommaSeparatedList extends String
 
     public function createStorageColumns()
     {
-        return [new String($this->columnName, $this->maximumLength, "")];
+        return [new StringColumn($this->columnName, $this->maximumLength, "")];
     }
 }

--- a/src/Schema/Columns/EncryptedString.php
+++ b/src/Schema/Columns/EncryptedString.php
@@ -18,10 +18,10 @@
 
 namespace Rhubarb\Stem\Schema\Columns;
 
-require_once __DIR__ . '/String.php';
+require_once __DIR__ . '/StringColumn.php';
 require_once __DIR__ . '/WithEncryptedText.php';
 
-class EncryptedString extends String
+class EncryptedString extends StringColumn
 {
     use WithEncryptedText;
 }

--- a/src/Schema/Columns/FloatColumn.php
+++ b/src/Schema/Columns/FloatColumn.php
@@ -20,7 +20,7 @@ namespace Rhubarb\Stem\Schema\Columns;
 
 require_once __DIR__ . "/Column.php";
 
-class Float extends Column
+class FloatColumn extends Column
 {
     public function getPhpType()
     {

--- a/src/Schema/Columns/StringColumn.php
+++ b/src/Schema/Columns/StringColumn.php
@@ -23,7 +23,7 @@ require_once __DIR__ . "/Column.php";
 /**
  * A string column
  */
-class String extends Column
+class StringColumn extends Column
 {
     public $maximumLength;
 

--- a/src/Schema/Columns/UUID.php
+++ b/src/Schema/Columns/UUID.php
@@ -11,7 +11,7 @@ namespace Rhubarb\Stem\Schema\Columns;
 
 use Rhubarb\Stem\Models\Model;
 
-class UUID extends String implements ModelValueInitialiserInterface
+class UUID extends StringColumn implements ModelValueInitialiserInterface
 {
     public function __construct($columnName = 'UUID')
     {
@@ -33,7 +33,7 @@ class UUID extends String implements ModelValueInitialiserInterface
      */
     public function createStorageColumns()
     {
-        return [ new String($this->columnName, 100, $this->defaultValue) ];
+        return [ new StringColumn($this->columnName, 100, $this->defaultValue) ];
     }
 
     private function generateUUID()

--- a/src/Schema/Columns/WithEncryptedText.php
+++ b/src/Schema/Columns/WithEncryptedText.php
@@ -40,7 +40,6 @@ trait WithEncryptedText
 
     public function createStorageColumns()
     {
-        $column = clone $this;
-        return [$column];
+        return [new StringColumn($this->columnName, $this->maximumLength, $this->defaultValue)];
     }
 }

--- a/tests/Fixtures/Account.php
+++ b/tests/Fixtures/Account.php
@@ -3,7 +3,7 @@
 namespace Rhubarb\Stem\Tests\Fixtures;
 
 use Rhubarb\Stem\Models\Model;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Schema\ModelSchema;
 
 /**
@@ -23,8 +23,8 @@ class Account extends Model
     {
         $schema = new ModelSchema('tblAccount');
         $schema->addColumn(
-            new String('AccountID', 50),
-            new String('AccountName', 50)
+            new StringColumn('AccountID', 50),
+            new StringColumn('AccountName', 50)
         );
         $schema->uniqueIdentifierColumnName = 'AccountID';
 

--- a/tests/Fixtures/Category.php
+++ b/tests/Fixtures/Category.php
@@ -4,7 +4,7 @@ namespace Rhubarb\Stem\Tests\Fixtures;
 
 use Rhubarb\Stem\Models\Model;
 use Rhubarb\Stem\Schema\Columns\AutoIncrement;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Schema\ModelSchema;
 
 class Category extends Model
@@ -20,7 +20,7 @@ class Category extends Model
 
         $schema->addColumn(
             new AutoIncrement("CategoryID"),
-            new String("CategoryName", 50)
+            new StringColumn("CategoryName", 50)
         );
 
         $schema->uniqueIdentifierColumnName = "CategoryID";

--- a/tests/Fixtures/Company.php
+++ b/tests/Fixtures/Company.php
@@ -23,7 +23,7 @@ use Rhubarb\Stem\Schema\Columns\DateTime;
 use Rhubarb\Stem\Schema\Columns\Integer;
 use Rhubarb\Stem\Schema\Columns\Json;
 use Rhubarb\Stem\Schema\Columns\Money;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Schema\Columns\Time;
 use Rhubarb\Stem\Schema\Columns\UUID;
 
@@ -42,7 +42,7 @@ class Company extends Model
 
         $schema->addColumn(
             new AutoIncrement("CompanyID"),
-            new String("CompanyName", 200),
+            new StringColumn("CompanyName", 200),
             new Money("Balance"),
             new Date("InceptionDate"),
             new DateTime("LastUpdatedDate"),

--- a/tests/Fixtures/Example.php
+++ b/tests/Fixtures/Example.php
@@ -9,7 +9,7 @@ use Rhubarb\Stem\Schema\Columns\Date;
 use Rhubarb\Stem\Schema\Columns\DateTime;
 use Rhubarb\Stem\Schema\Columns\Decimal;
 use Rhubarb\Stem\Schema\Columns\Integer;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Schema\Columns\Time;
 use Rhubarb\Stem\Schema\ModelSchema;
 
@@ -35,8 +35,8 @@ class Example extends Model
             new Integer("CompanyID", 0),
             new Date("DateOfBirth"),
             new DateTime("CreatedDate"),
-            new String("Forename", 100),
-            new String("Surname", 100),
+            new StringColumn("Forename", 100),
+            new StringColumn("Surname", 100),
             new Boolean("KeyContact"),
             new Time("CoffeeTime"),
             new Decimal("CreditLimit", 10, 2),

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -11,7 +11,7 @@ use Rhubarb\Stem\Schema\Columns\AutoIncrement;
 use Rhubarb\Stem\Schema\Columns\Boolean;
 use Rhubarb\Stem\Schema\Columns\Decimal;
 use Rhubarb\Stem\Schema\Columns\ForeignKey;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Schema\ModelSchema;
 
 /**
@@ -38,10 +38,10 @@ class User extends Model
             new AutoIncrement("UserID"),
             new ForeignKey("CompanyID"),
             new MySqlEnum("UserType", "Staff", ["Staff", "Administrator"]),
-            new String("Username", 40),
-            new String("Forename", 40),
-            new String("Surname", 40),
-            new String("Password", 120),
+            new StringColumn("Username", 40),
+            new StringColumn("Forename", 40),
+            new StringColumn("Surname", 40),
+            new StringColumn("Password", 120),
             new Boolean("Active", false),
             new Decimal("Wage")
         );

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -8,7 +8,7 @@ use Rhubarb\Stem\Exceptions\ModelConsistencyValidationException;
 use Rhubarb\Stem\Exceptions\RecordNotFoundException;
 use Rhubarb\Stem\Models\ModelEventManager;
 use Rhubarb\Stem\Repositories\MySql\Schema\Columns\MySqlDate;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Schema\ModelSchema;
 use Rhubarb\Stem\Schema\SolutionSchema;
 use Rhubarb\Stem\Tests\Fixtures\Account;
@@ -378,7 +378,7 @@ class ModelTest extends ModelUnitTestCase
 
         $schema = $example->getColumnSchemaForColumnReference("Forename");
 
-        $this->assertInstanceOf(String::class, $schema);
+        $this->assertInstanceOf(StringColumn::class, $schema);
         $this->assertEquals("Forename", $schema->columnName);
 
         $schema = $example->getColumnSchemaForColumnReference("ExampleRelationshipName.InceptionDate");

--- a/tests/Repositories/MySql/Schema/MySqlComparisonSchemaTest.php
+++ b/tests/Repositories/MySql/Schema/MySqlComparisonSchemaTest.php
@@ -4,7 +4,7 @@ namespace Rhubarb\Stem\Tests\Repositories\MySql\Schema;
 
 use Rhubarb\Stem\Repositories\MySql\MySql;
 use Rhubarb\Stem\Repositories\MySql\Schema\MySqlComparisonSchema;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Tests\Fixtures\Company;
 use Rhubarb\Stem\Tests\Fixtures\User;
 use Rhubarb\Stem\Tests\Repositories\MySql\MySqlTestCase;
@@ -87,7 +87,7 @@ class MySqlComparisonSchemaTest extends MySqlTestCase
 
         $this->assertFalse($compareTo->createAlterTableStatementFor($comparisonSchema));
 
-        $schema->addColumn(new String("Town", 60, null));
+        $schema->addColumn(new StringColumn("Town", 60, null));
 
         $compareTo = MySqlComparisonSchema::fromMySqlSchema($schema);
 

--- a/tests/Repositories/MySql/Schema/MySqlSchemaTest.php
+++ b/tests/Repositories/MySql/Schema/MySqlSchemaTest.php
@@ -10,7 +10,7 @@ use Rhubarb\Stem\Repositories\MySql\Schema\MySqlComparisonSchema;
 use Rhubarb\Stem\Repositories\MySql\Schema\MySqlModelSchema;
 use Rhubarb\Stem\Repositories\Repository;
 use Rhubarb\Stem\Schema\Columns\AutoIncrement;
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Tests\Fixtures\Example;
 use Rhubarb\Stem\Tests\Repositories\MySql\MySqlTestCase;
 
@@ -32,7 +32,7 @@ class MySqlSchemaTest extends MySqlTestCase
         $schema = new MysqlModelSchema("tblExample");
 
         $schema->addColumn(new AutoIncrement("ID"));
-        $schema->addColumn(new String("Name", 40, "StrangeDefault"));
+        $schema->addColumn(new StringColumn("Name", 40, "StrangeDefault"));
         $schema->addColumn(new MySqlEnum("Type", "A", ["A", "B", "C"]));
 
         $schema->addIndex(new Index("ID", Index::PRIMARY));
@@ -57,10 +57,10 @@ class MySqlSchemaTest extends MySqlTestCase
         $schema = new MySqlModelSchema("tblExample");
 
         $schema->addColumn(new AutoIncrement("ID"));
-        $schema->addColumn(new String("Name", 40, "StrangeDefault"));
+        $schema->addColumn(new StringColumn("Name", 40, "StrangeDefault"));
         $schema->addColumn(new MySqlEnum("Type", "A", ["A", "B", "C"]));
         $schema->addColumn(new MySqlEnum("Type", "B", ["A", "B", "C", "D"]));
-        $schema->addColumn(new String("Town", 60, null));
+        $schema->addColumn(new StringColumn("Town", 60, null));
 
         $schema->addIndex(new Index("ID", Index::PRIMARY));
 

--- a/tests/Schema/ModelSchemaTest.php
+++ b/tests/Schema/ModelSchemaTest.php
@@ -2,7 +2,7 @@
 
 namespace Rhubarb\Stem\Tests\Schema;
 
-use Rhubarb\Stem\Schema\Columns\String;
+use Rhubarb\Stem\Schema\Columns\StringColumn;
 use Rhubarb\Stem\Schema\ModelSchema;
 use Rhubarb\Stem\Tests\Fixtures\ModelUnitTestCase;
 
@@ -12,8 +12,8 @@ class ModelSchemaTest extends ModelUnitTestCase
     {
         $schema = new ModelSchema("test");
         $schema->addColumn(
-            new String("Bob", 100),
-            new String("Alice", 100)
+            new StringColumn("Bob", 100),
+            new StringColumn("Alice", 100)
         );
 
         $columns = $schema->getColumns();


### PR DESCRIPTION
We can't use String or Float as a class name in PHP 7. 

Renaming these columns obviously has a knock-on effect on many other modules:

https://github.com/RhubarbPHP/Scaffold.TokenBasedRestApi/pull/3
https://github.com/RhubarbPHP/Scaffold.SavedTabs/pull/1
https://github.com/RhubarbPHP/Scaffold.RepositoryLog/pull/1
https://github.com/RhubarbPHP/Scaffold.BackgroundTasks/pull/7
https://github.com/RhubarbPHP/Scaffold.AuthenticationWithRoles/pull/4
https://github.com/RhubarbPHP/Module.Leaf/pull/16
https://github.com/RhubarbPHP/Scaffold.Authentication/pull/6

And those are just the ones I had in Unislim when I refactored. We'll need to check for usage in the other modules too.

The best strategy might be for everyone to use phpstorm's refactoring tools in their existing rhubarb projects before pulling this, which will allow them to easily replace all usages of these column classes in their existing models.