### PR TITLE
Timezone magic

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -93,6 +93,7 @@ abstract class Model extends ModelState
     public function __clone()
     {
         $this->setUniqueIdentifier(null);
+        $this->onNewModelInitialised();
     }
 
     /**

--- a/src/Repositories/MySql/MySql.php
+++ b/src/Repositories/MySql/MySql.php
@@ -676,7 +676,7 @@ class MySql extends PdoRepository
                     [\PDO::ERRMODE_EXCEPTION => true]
                 );
 
-                $timeZone = $pdo->query("SELECT IF(@@session.time_zone = 'SYSTEM', @@system_time_zone, @@session.time_zone)");
+                $timeZone = $pdo->query("SELECT @@system_time_zone");
                 if ($timeZone->rowCount()) {
                     $settings->RepositoryTimeZone = new \DateTimeZone($timeZone->fetchColumn());
                 }

--- a/src/Repositories/MySql/Schema/Columns/MySqlDateColumn.php
+++ b/src/Repositories/MySql/Schema/Columns/MySqlDateColumn.php
@@ -22,6 +22,7 @@ use Rhubarb\Crown\DateTime\RhubarbDate;
 use Rhubarb\Crown\DateTime\RhubarbDateTime;
 use Rhubarb\Stem\Schema\Columns\Column;
 use Rhubarb\Stem\Schema\Columns\DateColumn;
+use Rhubarb\Stem\StemSettings;
 
 require_once __DIR__ . "/../../../../Schema/Columns/DateColumn.php";
 require_once __DIR__ . "/MySqlColumn.php";
@@ -51,11 +52,7 @@ class MySqlDateColumn extends DateColumn
             $data = new RhubarbDateTime($data[$this->columnName]);
 
             if ($data->isValidDateTime()) {
-                $date = clone $data;
-                // Normalise timezones to default system timezone when stored in DB
-                $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-
-                $date = $date->format("Y-m-d");
+                $date = $data->format("Y-m-d");
             } else {
                 $date = "0000-00-00";
             }

--- a/src/Repositories/MySql/Schema/Columns/MySqlDateTimeColumn.php
+++ b/src/Repositories/MySql/Schema/Columns/MySqlDateTimeColumn.php
@@ -21,6 +21,7 @@ namespace Rhubarb\Stem\Repositories\MySql\Schema\Columns;
 use Rhubarb\Crown\DateTime\RhubarbDateTime;
 use Rhubarb\Stem\Schema\Columns\Column;
 use Rhubarb\Stem\Schema\Columns\DateTimeColumn;
+use Rhubarb\Stem\StemSettings;
 
 require_once __DIR__ . "/../../../../Schema/Columns/DateTimeColumn.php";
 require_once __DIR__ . "/MySqlColumn.php";
@@ -58,8 +59,12 @@ class MySqlDateTimeColumn extends DateTimeColumn
 
             if ($data->isValidDateTime()) {
                 $date = clone $data;
-                // Normalise timezones to default system timezone when stored in DB
-                $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
+                $settings = new StemSettings();
+                if ($settings->RepositoryTimeZone) {
+                    // Normalise timezones to default system timezone when stored in DB
+                    $date->setTimezone($settings->RepositoryTimeZone);
+                }
 
                 $date = $date->format("Y-m-d H:i:s");
             } else {
@@ -73,7 +78,12 @@ class MySqlDateTimeColumn extends DateTimeColumn
     public function getTransformFromRepository()
     {
         return function ($data) {
-            return new RhubarbDateTime($data[$this->columnName]);
+            $settings = new StemSettings();
+            $dateTime = new RhubarbDateTime($data[$this->columnName], $settings->RepositoryTimeZone);
+            if ($settings->ProjectTimeZone) {
+                $dateTime->setTimezone($settings->ProjectTimeZone);
+            }
+            return $dateTime;
         };
     }
 }

--- a/src/StemSettings.php
+++ b/src/StemSettings.php
@@ -26,6 +26,8 @@ namespace Rhubarb\Stem;
  * @property string $Username
  * @property string $Password
  * @property string $Database
+ * @property \DateTimeZone $RepositoryTimeZone
+ * @property \DateTimeZone $ProjectTimeZone
  */
 class StemSettings extends \Rhubarb\Crown\Settings
 {
@@ -34,5 +36,6 @@ class StemSettings extends \Rhubarb\Crown\Settings
         parent::initialiseDefaultValues();
 
         $this->Port = 3306;
+        $this->ProjectTimeZone = new \DateTimeZone(date_default_timezone_get());
     }
 }


### PR DESCRIPTION
A silver bullet for timezone handling. Hopefully.

Paired with https://github.com/RhubarbPHP/Rhubarb/pull/33

MySql DateTimes are stored without a time zone, the idea being that all DateTimes are stored in the same timezone as determined by the server's timezone setting. It probably makes most sense to keep this as UTC. 

These changes deal with converting any times to be stored from their current timezone into the MySql server's timezone, and on retrieval, converting them back into a project default timezone (set from the PHP default timezone, but overridable in project settings).