### PR TITLE
Making filter passing more flexible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.1.x
+
+* Change: Group now accepts passing in of filters as parameters as well as in an array.
+* Change: Model::find() now accepts multiple filters as parameters -> will make an 'And' Group of the filters.
+* Change: Collection::filter() now accepts multiple filters as parameters -> will make an 'And' Group of the filters.
+
 ### 1.1.0
 
 * Added:    New ColumnIntersectsCollection filter type.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "rhubarbphp/custard" : "^1.0.0",
     "rhubarbphp/module-build-status-updater": "^1.0.4",
     "tan-tan-kanarek/github-php-client": "^1.0.0",
-    "codeception/codeception": "^2.0.0",
+    "codeception/codeception": "2.1.8",
     "phploc/phploc": "^3.0.0",
     "theseer/phpdox": "*",
     "phpmd/phpmd": "^2.0.0",

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -19,6 +19,9 @@ $company = new Company( 1 );
 $contacts = $company->Contacts;
 ```
 
+`Model::find()` and `Collection::filter()` can be given any number of filters as arguments and they will formed
+into an `AndGroup` filter. They also support passing in filters as a single array argument.
+
 ## Iteration
 
 As the `Collection` class implements `\Iterator`, `\ArrayAccess` and `\Countable` you can use the

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -400,6 +400,10 @@ class Collection implements \ArrayAccess, \Iterator, \Countable
             $andGroup->addFilters($filter);
         }
         
+        if (sizeof($filters) == 1){
+            $andGroup = $filters[0];
+        }
+        
         if (is_null($this->filter)) {
             $this->filter = $andGroup;
         } else {

--- a/src/Filters/AndGroup.php
+++ b/src/Filters/AndGroup.php
@@ -22,8 +22,8 @@ require_once __DIR__ . '/Group.php';
 
 class AndGroup extends Group
 {
-    public function __construct($filters = [])
+    public function __construct(...$filters)
     {
-        parent::__construct("AND", $filters);
+        parent::__construct("AND", ...$filters);
     }
 }

--- a/src/Filters/Group.php
+++ b/src/Filters/Group.php
@@ -45,9 +45,16 @@ class Group extends Filter
     protected $booleanType = "And";
 
 
-    public function __construct($booleanType = "And", $filters = [])
+    public function __construct($booleanType = "And", ...$filters)
     {
         $this->booleanType = $booleanType;
+        
+        if (sizeof($filters) == 0){
+            return;
+        }
+        if (is_array($filters[0])){
+            $filters = $filters[0];
+        }
 
         $this->filters = $filters;
     }

--- a/src/Filters/OrGroup.php
+++ b/src/Filters/OrGroup.php
@@ -22,8 +22,8 @@ require_once __DIR__ . '/Group.php';
 
 class OrGroup extends Group
 {
-    public function __construct($filters = [])
+    public function __construct(...$filters)
     {
-        parent::__construct("OR", $filters);
+        parent::__construct("OR", ...$filters);
     }
 }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -29,6 +29,7 @@ use Rhubarb\Stem\Exceptions\DeleteModelException;
 use Rhubarb\Stem\Exceptions\ModelConsistencyValidationException;
 use Rhubarb\Stem\Exceptions\RecordNotFoundException;
 use Rhubarb\Stem\Filters\Filter;
+use Rhubarb\Stem\Filters\Group;
 use Rhubarb\Stem\Repositories\Repository;
 use Rhubarb\Stem\Schema\Columns\ModelValueInitialiserInterface;
 use Rhubarb\Stem\Schema\ModelSchema;
@@ -401,17 +402,12 @@ abstract class Model extends ModelState
      * @param Filter $filter
      * @return Collection|static[]
      */
-    public static function find(Filter $filter = null)
+    public static function find(Filter ...$filters)
     {
         $modelClass = get_called_class();
-
-        $collections = new Collection($modelClass);
-
-        if ($filter !== null) {
-            $collections->filter($filter);
-        }
-
-        return $collections;
+        $collection = new Collection($modelClass);
+        $collection->filter(...$filters);
+        return $collection;
     }
 
     /**

--- a/tests/unit/Filters/GroupTest.php
+++ b/tests/unit/Filters/GroupTest.php
@@ -3,11 +3,13 @@
 namespace Rhubarb\Stem\Tests\unit\Filters;
 
 use Rhubarb\Stem\Collections\Collection;
+use Rhubarb\Stem\Filters\AndGroup;
 use Rhubarb\Stem\Filters\Contains;
 use Rhubarb\Stem\Filters\Equals;
 use Rhubarb\Stem\Filters\GreaterThan;
 use Rhubarb\Stem\Filters\Group;
 use Rhubarb\Stem\Filters\LessThan;
+use Rhubarb\Stem\Filters\OrGroup;
 use Rhubarb\Stem\Tests\unit\Fixtures\Example;
 use Rhubarb\Stem\Tests\unit\Fixtures\ModelUnitTestCase;
 
@@ -144,5 +146,49 @@ class GroupTest extends ModelUnitTestCase
         $this->assertNotEquals(1, $model->CompanyID);
         $this->assertNotEquals("Cuthbert", $model->Surname);
         $this->assertNotEquals("Andrew", $model->Forename);
+    }
+
+    public function testAndOrGroupsParametersNotAsArray()
+    {
+        $andGroup = new AndGroup(new Equals("Forename", "John"), new Equals("Surname", "Luc"));
+        $contacts = Example::find($andGroup);
+        $model = $contacts[0];
+        $this->assertEquals("John", $model->Forename);
+        $this->assertEquals("Luc", $model->Surname);
+
+        $orGroup = new OrGroup(new Equals("Forename", "John"), new Equals("Surname", "Luc"));
+        $contacts = Example::find($orGroup);
+        $model = $contacts[0];
+        $this->assertEquals("John", $model->Forename);
+        $this->assertEquals("Joe", $model->Surname);
+
+        $contacts = Example::find(new Equals("Forename", "John"), new Equals("Surname", "Luc"));
+    }
+
+    public function testFindAutomaticAndFilterForSeveralParameters()
+    {
+        $contacts = Example::find(new Equals("Forename", "John"), new Equals("Surname", "Luc"));
+        $model = $contacts[0];
+        $this->assertEquals("John", $model->Forename);
+        $this->assertEquals("Luc", $model->Surname);
+    }
+
+    public function testFilterAutomaticAndFilterForSeveralParameters()
+    {
+        $contacts = $this->list->filter(
+            new Contains("Forename", "Joh", true),
+            new Contains("Surname", "Joh", true)
+        );
+        $model = $contacts[0];
+        $this->assertEquals("John", $model->Forename);
+        $this->assertEquals("Johnson", $model->Surname);
+
+        $contacts2 = $this->list->filter([
+            new Contains("Forename", "Joh", true),
+            new Contains("Surname", "Joh", true)
+        ]);
+        $model = $contacts2[0];
+        $this->assertEquals("John", $model->Forename);
+        $this->assertEquals("Johnson", $model->Surname);
     }
 }


### PR DESCRIPTION
Group now accepts passing in of filters as parameters as well as in an array.

Model::find() now accepts multiple filters as parameters -> will make an 'And' Group of the filters.

Collection::filter() now accepts multiple filters as parameters -> will make an 'And' Group of the filters.