### PR TITLE
Respecting what the model says it should return

### DIFF
--- a/src/UrlHandlers/ModelCollectionHandler.php
+++ b/src/UrlHandlers/ModelCollectionHandler.php
@@ -50,7 +50,9 @@ abstract class ModelCollectionHandler extends UrlHandler
      */
     public function getModelCollection()
     {
-        return new RepositoryCollection($this->modelName);
+        $modelClassName = SolutionSchema::getModelClass($this->modelName);
+
+        return $modelClassName::all();
     }
 
     public function getModelObject()


### PR DESCRIPTION
E.g. if we want to filter “deleted” items from a collection by default (by a “deleted” boolean column) we would implement this via a filter in our find() or all() methods. Now, the default model collection respects this.