### PR TITLE
Fix for filtering columns with duplicate names

### DIFF
--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -458,8 +458,8 @@ abstract class Collection implements \ArrayAccess, \Iterator, \Countable
             }
 
             $this->aliasedColumns[$alias] = $column;
-            $this->aliasedColumnsToCollectionReference[$column] = $collection->getUniqueReference();
-            $this->aliasedColumnsToCollection[$column] = $collection;
+            $this->aliasedColumnsToCollectionReference[$alias] = $collection->getUniqueReference();
+            $this->aliasedColumnsToCollection[$alias] = $collection;
 
             foreach ($childAggregates as $aggregate) {
                 if ($aggregate->getAlias() == $column) {

--- a/src/Repositories/MySql/Filters/MySqlFilterTrait.php
+++ b/src/Repositories/MySql/Filters/MySqlFilterTrait.php
@@ -80,17 +80,13 @@ trait MySqlFilterTrait
 
     protected static function getTableAlias($originalFilter, Collection $collection)
     {
-        $tableAlias = null;
-
-        $columnName = self::getRealColumnName($originalFilter, $collection);
-
         $aliases = $collection->getAliasedColumnsToCollectionReference();
 
-        if (isset($aliases[$columnName])) {
-            $tableAlias = $aliases[$columnName];
+        if (isset($aliases[$originalFilter->columnName])) {
+            return $aliases[$originalFilter->columnName];
         }
 
-        return $tableAlias;
+        return null;
     }
 
     protected static function getRealColumnName($originalFilter, Collection $collection)


### PR DESCRIPTION
When attempting to filter on a collection with multiple columns of the same name, the filter could only be applied to the last one. It now uses aliases to allow you to specify the correct column by giving it a unique alias and referring to that.