### PR TITLE
MySql JSON type support

### DIFF
--- a/src/Filters/Literal.php
+++ b/src/Filters/Literal.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Stem\Filters;
+
+require_once __DIR__ . "/Filter.php";
+
+use Rhubarb\Stem\Collections\Collection;
+use Rhubarb\Stem\Collections\RepositoryCollection;
+use Rhubarb\Stem\Models\Model;
+
+/**
+ * Removes the records NOT selected by the filter in the constructor.
+ *
+ * This will in effect reverse the passed filters selection.
+ */
+class Literal extends Filter
+{
+    protected $literalWhereExpression;
+
+    public function __construct($literalWhereExpression)
+    {
+        $this->literalWhereExpression = $literalWhereExpression;
+    }
+
+    public function evaluate(Model $model)
+    {
+        return true;
+    }
+
+    public function checkForRelationshipIntersections(Collection $collection, $createIntersectionCallback)
+    {
+    }
+}

--- a/src/Repositories/MySql/Filters/MySqlLiteral.php
+++ b/src/Repositories/MySql/Filters/MySqlLiteral.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Rhubarb\Stem\Repositories\MySql\Filters;
+
+use Rhubarb\Stem\Collections\Collection;
+use Rhubarb\Stem\Exceptions\CreatedIntersectionException;
+use Rhubarb\Stem\Filters\Filter;
+use Rhubarb\Stem\Filters\Literal;
+use Rhubarb\Stem\Models\Model;
+use Rhubarb\Stem\Repositories\Repository;
+use Rhubarb\Stem\Sql\LiteralWhereExpression;
+use Rhubarb\Stem\Sql\WhereExpressionCollector;
+
+class MySqlLiteral extends Literal
+{
+    use MySqlFilterTrait;
+
+    protected $literalWhereExpression;
+
+    public function __construct($literalWhereExpression)
+    {
+        $this->literalWhereExpression = $literalWhereExpression;
+    }
+
+    protected static function canFilter(Collection $collection, Repository $repository, $columnName)
+    {
+        return true;
+    }
+
+    protected function doFilterWithRepository(
+        Collection $collection,
+        Repository $repository,
+        WhereExpressionCollector $whereExpressionCollector,
+        &$params
+    ) {
+        $this->createColumnWhereClauseExpression(null, null, $collection, $repository, $whereExpressionCollector, $params);
+
+        return true;
+    }
+
+    protected function createColumnWhereClauseExpression(
+        $sqlOperator,
+        $value,
+        Collection $collection,
+        Repository $repository,
+        WhereExpressionCollector $whereExpressionCollector,
+        &$params
+    ) {
+        $whereExpressionCollector->addWhereExpression(new LiteralWhereExpression($this->literalWhereExpression));
+    }
+
+    /**
+     * @param Literal $filter
+     * @return MySqlLiteral
+     */
+    public static function fromGenericFilter(Filter $filter)
+    {
+        return new self($filter->literalWhereExpression);
+    }
+}

--- a/src/Repositories/MySql/Schema/Columns/MySqlBinaryDataColumn.php
+++ b/src/Repositories/MySql/Schema/Columns/MySqlBinaryDataColumn.php
@@ -22,7 +22,6 @@ use Rhubarb\Stem\Repositories\MySql\Schema\Columns\MySqlColumn;
 use Rhubarb\Stem\Schema\Columns\BinaryDataColumn;
 use Rhubarb\Stem\Schema\Columns\Column;
 
-require_once __DIR__ . "/MySqlColumn.php";
 require_once __DIR__ . "/../../../../Schema/Columns/BinaryDataColumn.php";
 
 /**
@@ -31,16 +30,9 @@ require_once __DIR__ . "/../../../../Schema/Columns/BinaryDataColumn.php";
  */
 class MySqlBinaryDataColumn extends BinaryDataColumn
 {
-    use MySqlColumn;
-
-    public function __construct($columnName)
-    {
-        parent::__construct($columnName);
-    }
-
     public function getDefinition()
     {
-        return "`" . $this->columnName . "` longblob " . $this->getDefaultDefinition();
+        return "`" . $this->columnName . "` longblob";
     }
 
     protected static function fromGenericColumnType(Column $genericColumn)

--- a/src/Repositories/MySql/Schema/Columns/MySqlJsonColumn.php
+++ b/src/Repositories/MySql/Schema/Columns/MySqlJsonColumn.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Stem\Repositories\MySql\Schema\Columns;
+
+use Rhubarb\Stem\Schema\Columns\Column;
+use Rhubarb\Stem\Schema\Columns\JsonColumn;
+
+require_once __DIR__ . "/../../../../Schema/Columns/JsonColumn.php";
+
+class MySqlJsonColumn extends JsonColumn
+{
+    public function getDefinition()
+    {
+        return "`" . $this->columnName . "` json";
+    }
+
+    protected static function fromGenericColumnType(Column $genericColumn)
+    {
+        return new self($genericColumn->columnName);
+    }
+
+    public function createStorageColumns()
+    {
+        return [$this];
+    }
+}

--- a/src/Repositories/MySql/Schema/Columns/MySqlJsonColumn.php
+++ b/src/Repositories/MySql/Schema/Columns/MySqlJsonColumn.php
@@ -25,9 +25,14 @@ require_once __DIR__ . "/../../../../Schema/Columns/JsonColumn.php";
 
 class MySqlJsonColumn extends JsonColumn
 {
+    public function getDefaultDefinition()
+    {
+        return ($this->defaultValue === null) ? "DEFAULT NULL" : "NOT NULL";
+    }
+
     public function getDefinition()
     {
-        return "`" . $this->columnName . "` json";
+        return "`" . $this->columnName . "` json " . $this->getDefaultDefinition();
     }
 
     protected static function fromGenericColumnType(Column $genericColumn)


### PR DESCRIPTION
Added a MySqlJsonColumn field which uses the JSON type in MySQL.
Added a Literal filter for supplying literal MySql to be included in a WHERE expression, which allows usage of e.g. MySQL JSON query functions.