### PR TITLE
Expiration Check for Login Provider

### DIFF
--- a/src/Interfaces/CheckExpiredModelInterface.php
+++ b/src/Interfaces/CheckExpiredModelInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Stem\Interfaces;
+
+/**
+ * The following interface is used to allow enable validation of whether the model
+ * has expired.
+ * For example: It can be used to validate whether a users password has now expired
+ */
+interface CheckExpiredModelInterface
+{
+    public function hasModelExpired();
+}

--- a/src/LoginProviders/ModelLoginProvider.php
+++ b/src/LoginProviders/ModelLoginProvider.php
@@ -22,12 +22,14 @@ use Rhubarb\Crown\Encryption\HashProvider;
 use Rhubarb\Crown\Exceptions\ImplementationException;
 use Rhubarb\Crown\Logging\Log;
 use Rhubarb\Crown\LoginProviders\Exceptions\LoginDisabledException;
+use Rhubarb\Crown\LoginProviders\Exceptions\LoginExpiredException;
 use Rhubarb\Crown\LoginProviders\Exceptions\LoginFailedException;
 use Rhubarb\Crown\LoginProviders\Exceptions\NotLoggedInException;
 use Rhubarb\Crown\LoginProviders\LoginProvider;
 use Rhubarb\Stem\Collections\RepositoryCollection;
 use Rhubarb\Stem\Exceptions\RecordNotFoundException;
 use Rhubarb\Stem\Filters\Equals;
+use Rhubarb\Stem\Interfaces\CheckExpiredModelInterface;
 use Rhubarb\Stem\Models\Model;
 use Rhubarb\Stem\Schema\SolutionSchema;
 
@@ -90,6 +92,11 @@ class ModelLoginProvider extends LoginProvider
             if ($existingActiveUsers > 1) {
                 Log::debug("Login failed for {$username} - the username wasn't unique", "LOGIN");
                 throw new LoginFailedException();
+            }
+
+            if ($user instanceof CheckExpiredModelInterface && $user->hasModelExpired()) {
+                Log::debug("Login failed for {$username} - the login has now expired", "LOGIN");
+                throw new LoginExpiredException();
             }
         }
 

--- a/tests/unit/Fixtures/TestExpiredLoginProvider.php
+++ b/tests/unit/Fixtures/TestExpiredLoginProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rhubarb\Stem\Tests\unit\Fixtures;
+
+use Rhubarb\Stem\LoginProviders\ModelLoginProvider;
+
+class TestExpiredLoginProvider extends ModelLoginProvider
+{
+    public function __construct()
+    {
+        parent::__construct(TestExpiredUser::class, "Username", "Password", "Active");
+    }
+}

--- a/tests/unit/Fixtures/TestExpiredUser.php
+++ b/tests/unit/Fixtures/TestExpiredUser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rhubarb\Stem\Tests\unit\Fixtures;
+
+use Rhubarb\Stem\Interfaces\CheckExpiredModelInterface;
+
+class TestExpiredUser extends User implements CheckExpiredModelInterface
+{
+    public function hasModelExpired()
+    {
+        return true;
+    }
+}

--- a/tests/unit/LoginProviders/ModelLoginProviderTest.php
+++ b/tests/unit/LoginProviders/ModelLoginProviderTest.php
@@ -5,9 +5,12 @@ namespace Rhubarb\Stem\Tests\unit\LoginProviders;
 use Rhubarb\Crown\Encryption\HashProvider;
 use Rhubarb\Crown\Encryption\Sha512HashProvider;
 use Rhubarb\Crown\LoginProviders\Exceptions\LoginDisabledException;
+use Rhubarb\Crown\LoginProviders\Exceptions\LoginExpiredException;
 use Rhubarb\Crown\LoginProviders\Exceptions\LoginFailedException;
 use Rhubarb\Crown\LoginProviders\Exceptions\NotLoggedInException;
 use Rhubarb\Crown\Tests\Fixtures\TestCases\RhubarbTestCase;
+use Rhubarb\Stem\Tests\unit\Fixtures\TestExpiredLoginProvider;
+use Rhubarb\Stem\Tests\unit\Fixtures\TestExpiredUser;
 use Rhubarb\Stem\Tests\unit\Fixtures\TestLoginProvider;
 use Rhubarb\Stem\Tests\unit\Fixtures\User;
 
@@ -116,5 +119,22 @@ class ModelLoginProviderTest extends RhubarbTestCase
 
         $this->assertTrue($testLoginProvider->isLoggedIn());
         $this->assertEquals($user->UniqueIdentifier, $testLoginProvider->getModel()->UniqueIdentifier);
+    }
+
+    public function testExpiredLogin()
+    {
+        $user = new TestExpiredUser();
+        $user->Username = "expiredlogin";
+        $user->Password = "password";
+        $user->save();
+
+        try {
+            $testLoginProvider = new TestExpiredLoginProvider();
+            $testLoginProvider->login($user->Username, $user->Password);
+
+            $this->fail("Expected User login to be expired");
+        } catch (LoginExpiredException $exception) {
+            $this->assertEquals("Sorry, your login has now expired. Please contact the system administrator to address this issue.", $exception->getPublicMessage());
+        }
     }
 }


### PR DESCRIPTION
Adding logic to support checking if a user login has expired and can then ensure a relevant exception is thrown to cater for this scenario.