### PR TITLE
Issue when creating cache folder

### DIFF
--- a/src/Schema/SolutionSchema.php
+++ b/src/Schema/SolutionSchema.php
@@ -688,7 +688,7 @@ abstract class SolutionSchema
      */
     public function checkModelSchemasIfNecessary()
     {
-        $cachePath = Application::current()->tempPath."/cache/";
+        $cachePath = Application::current()->applicationRootPath."/cache/";
 
         if (!file_exists($cachePath."schema-versions")) {
             mkdir($cachePath."schema-versions", 0777, true);


### PR DESCRIPTION
Hi @acuthbert 

Can we discuss this change as I realise it is a reverse of the change made at version 1.5.6 ? Do we need to configure anything to support Application::current()->tempPath as this would not work for me and always returned a blank string.

The following Pull Request ensures the cache folder is created at the Application Root folder when called from the checkModelSchemasIfNecessary method where it was using the tempPath rather than the applicationRootPath when creating the cache folder.

