### PR TITLE
MySQL Repository use mysql server time_zone instead of system_time_zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+### 1.6.1
+
+* Changed: When creating connection, use DB time_zone rather than system_time_zone to set repositoryDateTime setting.
 
 ### 1.6
 

--- a/src/Repositories/MySql/MySql.php
+++ b/src/Repositories/MySql/MySql.php
@@ -704,10 +704,16 @@ class MySql extends PdoRepository
                     )
                 );
 
-                $timeZone = $pdo->query("SELECT @@system_time_zone");
+                $timeZone = $pdo->query("SELECT @@time_zone as tz, @@system_time_zone as stz");
                 if ($timeZone->rowCount()) {
-                    $settings->repositoryTimeZone = new \DateTimeZone($timeZone->fetchColumn());
+                    $timezones = $timeZone->fetch(\PDO::FETCH_ASSOC);
+                    if($timezones['tz'] === 'SYSTEM'){
+                        $settings->repositoryTimeZone = new \DateTimeZone($timezones['stz']);
+                    } else {
+                        $settings->repositoryTimeZone = new \DateTimeZone($timezones['tz']);
+                    }
                 }
+
                 if ($settings->charset) {
                     $statement = $pdo->prepare("SET NAMES :charset");
                     $statement->execute(['charset' => $settings->charset]);


### PR DESCRIPTION
To support different timezones on RDS. On RDS only time_zone can be changed, the system_time_zone cannot be changed.