### PR TITLE
Changes to join / groupby to allow parent aliasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@
 
 ### 1.8.4
 
- * Added:   beforeScenario and afterScenario hooks for improving scenario seeding
+* Added:   beforeScenario and afterScenario hooks for improving scenario seeding
 
- ### 1.8.3	
+ ### 1.8.3
 
- * Added:   Some pretty colours when showing seeding titles.	
+* Added:   Some pretty colours when showing seeding titles.
 
- ### 1.8.2	
+ ### 1.8.2
 
- * Added:   Bulk flag added to seed command. BulkScenario added.	
-* Changed: Truncation of data turned off by default when seeding.	
+* Added:   Bulk flag added to seed command. BulkScenario added.
+* Changed: Truncation of data turned off by default when seeding.
 * Added:   getPrerequisiteSeeders() can now return class names instead of seeding objects.
 
 ### 1.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 * Added:   beforeScenario and afterScenario hooks for improving scenario seeding
 
- ### 1.8.3
+### 1.8.3
 
 * Added:   Some pretty colours when showing seeding titles.
 
- ### 1.8.2
+### 1.8.2
 
 * Added:   Bulk flag added to seed command. BulkScenario added.
 * Changed: Truncation of data turned off by default when seeding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,8 @@
 # Change Log
 
-### 1.8.4
+### 1.8.5
 
-* Added:   beforeScenario and afterScenario hooks for improving scenario seeding
-
-### 1.8.3
-
-* Added:   Some pretty colours when showing seeding titles.
-
-### 1.8.2
-
-* Added:   Bulk flag added to seed command. BulkScenario added.
-* Changed: Truncation of data turned off by default when seeding.
-* Added:   getPrerequisiteSeeders() can now return class names instead of seeding objects.
+* Changed: MySql can now group/join by intersected columns using their name or aliased name
 
 ### 1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 * Changed: MySql can now group/join by intersected columns using their name or aliased name
 
+### 1.8.4
+
+ * Added:   beforeScenario and afterScenario hooks for improving scenario seeding
+
+ ### 1.8.3	
+
+ * Added:   Some pretty colours when showing seeding titles.	
+
+ ### 1.8.2	
+
+ * Added:   Bulk flag added to seed command. BulkScenario added.	
+* Changed: Truncation of data turned off by default when seeding.	
+* Added:   getPrerequisiteSeeders() can now return class names instead of seeding objects.
+
 ### 1.8.1
 
 * Fixed:   Stopped SchemaCommandTrait from trying to use the settings folder which might not exist.

--- a/src/Repositories/MySql/MySql.php
+++ b/src/Repositories/MySql/MySql.php
@@ -388,11 +388,9 @@ class MySql extends PdoRepository
                 $join->joinType = Join::JOIN_TYPE_LEFT;
             }
 
-            if (!isset($columns[$collectionJoin->sourceColumnName]) && isset($intersectionColumnAliases[$collectionJoin->sourceColumnName])) {
-                $join->parentTableAlias = $intersectionColumnAliases[$collectionJoin->sourceColumnName];
-            } else {
-                $join->parentTableAlias = $sqlStatement->getAlias();
-            }
+            $join->parentTableAlias = !isset($columns[$collectionJoin->sourceColumnName]) && isset($intersectionColumnAliases[$collectionJoin->sourceColumnName]) ?
+                $intersectionColumnAliases[$collectionJoin->sourceColumnName] :
+                $sqlStatement->getAlias();
 
             $join->parentColumn = $collectionJoin->sourceColumnName;
             $join->childColumn = $collectionJoin->targetColumnName;
@@ -564,12 +562,12 @@ class MySql extends PdoRepository
                     $group = $columnAliases[$group];
                 }
 
-                if (!isset($columns[$group]) && isset($intersectionColumnAliases[$group])){
-                    $tableAlias = $intersectionColumnAliases[$group];
-                    $sqlStatement->groups[] = new GroupExpression("`" . $tableAlias . "`.`" . $group . "`");
-                } else {
-                    $sqlStatement->groups[] = new GroupExpression("`" . $sqlStatement->getAlias() . "`.`" . $group . "`");
-                }
+                // Check if the column name is from an intersection and update the table alias accordingly.
+                $tableAlias = isset($columns[$group]) && isset($intersectionColumnAliases[$group]) ?
+                    $intersectionColumnAliases[$group] :
+                    $sqlStatement->getAlias();
+
+                $sqlStatement->groups[] = new GroupExpression("`" . $tableAlias . "`.`" . $group . "`");
             }
         }
 

--- a/src/Repositories/MySql/MySql.php
+++ b/src/Repositories/MySql/MySql.php
@@ -563,7 +563,7 @@ class MySql extends PdoRepository
                 }
 
                 // Check if the column name is from an intersection and update the table alias accordingly.
-                $tableAlias = isset($columns[$group]) && isset($intersectionColumnAliases[$group]) ?
+                $tableAlias = !isset($columns[$group]) && isset($intersectionColumnAliases[$group]) ?
                     $intersectionColumnAliases[$group] :
                     $sqlStatement->getAlias();
 

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -8,6 +8,7 @@ class Join extends SqlClause
     const JOIN_TYPE_INNER = "INNER JOIN";
     const JOIN_TYPE_RIGHT = "RIGHT JOIN";
 
+    public $parentTableAlias = "";
     public $parentColumn = "";
     public $childColumn = "";
     public $joinType = self::JOIN_TYPE_INNER;

--- a/src/Sql/SqlStatement.php
+++ b/src/Sql/SqlStatement.php
@@ -177,7 +177,7 @@ class SqlStatement extends SqlClause implements WhereExpressionCollector
         $sql = "UPDATE `".$this->schemaName."` AS `".$this->getAlias()."`";
 
         foreach($this->joins as $join){
-            $sql .= " ".$join->joinType." (".$join->getSql($this).") AS `".$join->statement->getAlias()."` ON `".$this->getAlias()."`.`".
+            $sql .= " ".$join->joinType." ".$joinsSql." AS `".$join->statement->getAlias()."` ON `".$join->parentTableAlias."`.`".
                 $join->parentColumn."` = `".$join->statement->getAlias()."`.`".$join->childColumn."`";
         }
 
@@ -215,7 +215,7 @@ class SqlStatement extends SqlClause implements WhereExpressionCollector
                 $joinsSql = "(".$joinsSql.")";
             }
 
-            $sql .= " ".$join->joinType." ".$joinsSql." AS `".$join->statement->getAlias()."` ON `".$this->getAlias()."`.`".
+            $sql .= " ".$join->joinType." ".$joinsSql." AS `".$join->statement->getAlias()."` ON `".$join->parentTableAlias."`.`".
                 $join->parentColumn."` = `".$join->statement->getAlias()."`.`".$join->childColumn."`";
         }
 

--- a/src/Sql/SqlStatement.php
+++ b/src/Sql/SqlStatement.php
@@ -177,7 +177,7 @@ class SqlStatement extends SqlClause implements WhereExpressionCollector
         $sql = "UPDATE `".$this->schemaName."` AS `".$this->getAlias()."`";
 
         foreach($this->joins as $join){
-            $sql .= " ".$join->joinType." ".$joinsSql." AS `".$join->statement->getAlias()."` ON `".$join->parentTableAlias."`.`".
+            $sql .= " ".$join->joinType." (".$join->getSql($this).") AS `".$join->statement->getAlias()."` ON `".$join->parentTableAlias."`.`".
                 $join->parentColumn."` = `".$join->statement->getAlias()."`.`".$join->childColumn."`";
         }
 


### PR DESCRIPTION
Updated the functionality around joining and grouping. This now checks if the column is available on the parent columns and if not it checks for pulled up columns and other joined tables.

Previously you could not join on a table or group by a table if the column you use using was from a different table.