### PR TITLE
Feature/fast counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.9.0
+
+* Changed: Collections now support per repository optimisation of collection counting. This is implemented
+           in MySql as a COUNT(*) on the original query. This results in more queries overall, but in many
+           cases greatly increased performance and reduced network traffic.
+
 ### 1.8.18
 
 * Changed: Further fixes for phpDocumentor

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -431,6 +431,8 @@ abstract class Collection implements \ArrayAccess, \Iterator, \Countable
     final public function clearIntersections()
     {
         $this->intersections = [];
+        
+        return $this;
     }
 
     /**

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -43,7 +43,7 @@ abstract class Collection implements \ArrayAccess, \Iterator, \Countable
      *
      * @var CollectionCursor
      */
-    private $collectionCursor;
+    protected $collectionCursor;
 
     /**
      * The only or top level group filter to apply to the list.

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -302,6 +302,16 @@ abstract class Collection implements \ArrayAccess, \Iterator, \Countable
     }
 
     /**
+     * Removes all groups
+     */
+    final public function clearGroups($columnName)
+    {
+        $this->groups = [];
+
+        return $this;
+    }
+
+    /**
      * Adds another sort condition.
      *
      * @param string $columnName The name of the column to sort on.
@@ -413,6 +423,14 @@ abstract class Collection implements \ArrayAccess, \Iterator, \Countable
         $this->invalidate();
 
         return ($result === null) ? $model : $result;
+    }
+
+    /**
+     * Removes all intersections
+     */
+    final public function clearIntersections()
+    {
+        $this->intersections = [];
     }
 
     /**
@@ -807,7 +825,7 @@ abstract class Collection implements \ArrayAccess, \Iterator, \Countable
         return $this->intersections;
     }
 
-    private function invalidate()
+    protected function invalidate()
     {
         $this->rangeApplied = false;
         $this->collectionCursor = null;
@@ -878,16 +896,10 @@ abstract class Collection implements \ArrayAccess, \Iterator, \Countable
     }
 
     /**
-     * Create a cursor for the collection if one has not been already.
-     *
-     * If the repository cannot handle any feature of the collection this function will 'polyfill' support.
+     * Performs some pre-query checks on our collection
      */
-    private function prepareCursor()
+    protected function prepareCollectionForExecution()
     {
-        if ($this->collectionCursor != null) {
-            // Cursor already exists, we shouldn't bother making a new one.
-            return;
-        }
 
         // Before we prepare the cursor we should ask all of our filters, sorts and aggregates to
         // check if they have any dot notations that need expanded into intersections.
@@ -915,7 +927,21 @@ abstract class Collection implements \ArrayAccess, \Iterator, \Countable
                 $this->groups[] = $uniqueIdentifier;
             }
         }
+    }
 
+    /**
+     * Create a cursor for the collection if one has not been already.
+     *
+     * If the repository cannot handle any feature of the collection this function will 'polyfill' support.
+     */
+    private function prepareCursor()
+    {
+        if ($this->collectionCursor != null) {
+            // Cursor already exists, we shouldn't bother making a new one.
+            return;
+        }
+
+        $this->prepareCollectionForExecution();
         $this->collectionCursor = $this->createCursor();
 
         /**

--- a/src/Collections/RepositoryCollection.php
+++ b/src/Collections/RepositoryCollection.php
@@ -71,6 +71,12 @@ class RepositoryCollection extends Collection
 
     public function count()
     {
+        // If we already have a cursor (i.e. data is already fetched) we already know how many
+        // rows we have.
+        if ($this->collectionCursor){
+            return $this->collectionCursor->count();
+        }
+
         if ($this->count === null){
             $this->prepareCollectionForExecution();
             $this->count = $this->getRepository()->countRowsInCollection($this);            

--- a/src/Collections/RepositoryCollection.php
+++ b/src/Collections/RepositoryCollection.php
@@ -67,6 +67,25 @@ class RepositoryCollection extends Collection
         return true;
     }
 
+    private $count = null;
+
+    public function count()
+    {
+        if ($this->count === null){
+            $this->prepareCollectionForExecution();
+            $this->count = $this->getRepository()->countRowsInCollection($this);            
+        }
+
+        return $this->count;
+    }
+
+    protected function invalidate()
+    {
+        parent::invalidate();
+
+        $this->count = null;
+    }
+
     protected function createCursor()
     {
         $repository = $this->getRepository();

--- a/src/Collections/UniqueIdentifierListCursor.php
+++ b/src/Collections/UniqueIdentifierListCursor.php
@@ -136,7 +136,6 @@ class UniqueIdentifierListCursor extends CollectionCursor
             $newoffset = $offset - count($this->uniqueIdentifiers);
             $values = array_values($this->duplicatedRows);
             $keys = array_keys($this->duplicatedRows);
-
             $id = rtrim($values[$newoffset], "_");
             $augmentationId = $keys[$newoffset];
         } else {

--- a/src/Repositories/Offline/Offline.php
+++ b/src/Repositories/Offline/Offline.php
@@ -81,8 +81,8 @@ class Offline extends Repository
         // has a method "prepareCursor". This actually executes the queries and afterwards
         // it tries to 'complete' filtering, sorting and aggregating in the event that some
         // of those could not be done in the repository back end store. However the Offline
-        // repository relies on that secondary behaviour to work (hence this class) is almost
-        // empty.
+        // repository relies on that secondary behaviour to work (hence this class is almost
+        // empty).
         //
         // It would have been better a) not to support post iteration filtering etc. anyway
         // as it's caused no end of performance problems and b) to have that code in here.

--- a/src/Repositories/Offline/Offline.php
+++ b/src/Repositories/Offline/Offline.php
@@ -20,6 +20,7 @@ namespace Rhubarb\Stem\Repositories\Offline;
 
 require_once __DIR__ . "/../Repository.php";
 
+use Rhubarb\Stem\Collections\RepositoryCollection;
 use Rhubarb\Stem\Models\Model;
 use Rhubarb\Stem\Repositories\Repository;
 use Rhubarb\Stem\Schema\Columns\AutoIncrementColumn;
@@ -72,5 +73,25 @@ class Offline extends Repository
     public function clearRepositoryData()
     {
         $this->clearObjectCache();
+    }
+
+    public function countRowsInCollection(RepositoryCollection $collection)
+    {
+        // Force a cursor to be made. This is a weakness in our placement of code. Collection
+        // has a method "prepareCursor". This actually executes the queries and afterwards
+        // it tries to 'complete' filtering, sorting and aggregating in the event that some
+        // of those could not be done in the repository back end store. However the Offline
+        // repository relies on that secondary behaviour to work (hence this class) is almost
+        // empty.
+        //
+        // It would have been better a) not to support post iteration filtering etc. anyway
+        // as it's caused no end of performance problems and b) to have that code in here.
+        // 
+        // However the existing design is non trivial to modify so for now we simply
+        // call offsetExists() which will result in prepareCursor() being called and then
+        // we try the count a second time. As a cursor now exists it will not come back
+        // so an infinite loop is avoided.
+        $collection->offsetExists(0);
+        return count($collection);
     }
 }

--- a/src/Repositories/PdoRepository.php
+++ b/src/Repositories/PdoRepository.php
@@ -235,12 +235,14 @@ abstract class PdoRepository extends Repository
         Log::createEntry(Log::PERFORMANCE_LEVEL | Log::REPOSITORY_LEVEL, function () use ($statement, $namedParameters, $connection) {
             $newStatement = $statement;
 
-            array_walk($namedParameters, function ($value, $key) use (&$newStatement, &$params, $connection) {
-                // Note this is not attempting to make secure queries - this is purely illustrative for the logs
-                // However we do at least do addslashes so if you want to cut and paste a query from the log to
-                // try it - it should work in most cases.
-                $newStatement = preg_replace('/(\:' . preg_quote($key) . ')([^\w]|$)/' , $connection->quote($value) . '$2', $newStatement);
-            });
+            if (is_array($namedParameters)){
+                array_walk($namedParameters, function ($value, $key) use (&$newStatement, &$params, $connection) {
+                    // Note this is not attempting to make secure queries - this is purely illustrative for the logs
+                    // However we do at least do addslashes so if you want to cut and paste a query from the log to
+                    // try it - it should work in most cases.
+                    $newStatement = preg_replace('/(\:' . preg_quote($key) . ')([^\w]|$)/' , $connection->quote($value) . '$2', $newStatement);
+                });
+            }
 
             return "Executing PDO statement " . $newStatement;
         }, "PDO");

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -302,7 +302,7 @@ abstract class Repository
      *
      * @param  RepositoryCollection $collection
      * @throws \Rhubarb\Stem\Exceptions\SortNotValidException
-     * @return ArrayAccess
+     * @return UniqueIdentifierListCursor
      */
     public function createCursorForCollection(RepositoryCollection $collection)
     {        

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -293,7 +293,7 @@ abstract class Repository
      * By default just gets a collection cursor and counts the rows.
      */
     public function countRowsInCollection(RepositoryCollection $collection)
-    {
+    {        
         return $this->createCursorForCollection($collection)->count();
     }
 
@@ -305,7 +305,7 @@ abstract class Repository
      * @return ArrayAccess
      */
     public function createCursorForCollection(RepositoryCollection $collection)
-    {
+    {        
         $ids = array_keys($this->cachedObjectData);
 
         return new UniqueIdentifierListCursor(array_values($ids), $this->modelClassName);

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -288,11 +288,21 @@ abstract class Repository
     }
 
     /**
+     * Provides an opportunity for a collection's size to be calculated in an optimised way
+     * 
+     * By default just gets a collection cursor and counts the rows.
+     */
+    public function countRowsInCollection(RepositoryCollection $collection)
+    {
+        return $this->createCursorForCollection($collection)->count();
+    }
+
+    /**
      * Get's a sorted list of unique identifiers for the supplied list.
      *
      * @param  RepositoryCollection $collection
      * @throws \Rhubarb\Stem\Exceptions\SortNotValidException
-     * @return array
+     * @return ArrayAccess
      */
     public function createCursorForCollection(RepositoryCollection $collection)
     {


### PR DESCRIPTION
* Changed: Collections now support per repository optimisation of collection counting. This is implemented
           in MySql as a COUNT(*) on the original query. This results in more queries overall, but in many
           cases greatly increased performance and reduced network traffic.

Note this change has resulted in much improved performance on Linergy (main overview load time from 7 seconds to < 1 second)

In particular the issue was noticed when counting the rows behind 'Tabs'. The Stem approach was to simple execute the query and then ask PDO how many rows it got. This was OK (ish) for paging - because the query had a limit and we used SQL_CALC_FOUND_ROWS there was only a small overhead. Even better there was a high liklihood that data would very shortly be iterated over for the table. With Tabs however the collection has no limit and on Linergy the query was a large result set (79,000 rows x about 30 columns). The overhead of data fetching just to get the counts was madness.

This change introduces count(*) for counts. In many cases that means we now do a count(*) just before we start to iterate on any collection. This also feels wrong, but in testing the performance benefits massively outweigh this downside.