### PR TITLE
Catch PDOException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### 1.9.5
+
+* Fixed:  PHP 8 makes PDO::ERRMODE_EXCEPTION the default, meaning the RepositoryStatementException was no longer being
+          caught as a PDOException was being thrown. Added a catch for PDOException.
+
 ### 1.9.4
 
 * Fixed:  PHP 8 has added supported for named arguments. This can cause problems when using call_user_func_array().

--- a/src/Repositories/PdoRepository.php
+++ b/src/Repositories/PdoRepository.php
@@ -247,10 +247,14 @@ abstract class PdoRepository extends Repository
             return "Executing PDO statement " . $newStatement;
         }, "PDO");
 
-        if (!$pdoStatement->execute($namedParameters)) {
-            $error = $pdoStatement->errorInfo();
+        try{
+            if (!$pdoStatement->execute($namedParameters)) {
+                $error = $pdoStatement->errorInfo();
 
-            throw new RepositoryStatementException($error[2], $statement);
+                throw new RepositoryStatementException($error[2], $statement);
+            }
+        }catch(\PDOException $exception){
+            throw new RepositoryStatementException($exception->getMessage(), $statement);
         }
 
         $insertedId = $connection->lastInsertId();


### PR DESCRIPTION
PHP 8 makes PDO::ERRMODE_EXCEPTION the default, meaning the RepositoryStatementException was no longer being caught as a PDOException was being thrown. Added a catch for PDOException.